### PR TITLE
Add `nasdaq-data-link`, `matplotlib`, and `nebari` to env

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -1,22 +1,21 @@
-# Uncomment/Add packages when needed
+# Add packages when needed
 
 name: nebari-demo
 channels:
 - conda-forge
 dependencies:
 - python=3.9
-- qhub
 - ipykernel
 - ipywidgets
-- papermill
 - numpy
 - pandas
+- matplotlib
 - s3fs
 - pyarrow
 - jupyterlab
-# - gdal
-# - rasterio
-- qhub-dask
+- jupyterlab-spellchecker
+- nebari-dask
+- pip
 - pip:
-  - kbatch
-  # - rio-cogeo
+  - nebari
+  - nasdaq-data-link


### PR DESCRIPTION
(Python version is 3.9 because I had some dependency conflicts with `pyarrow` on macOS 12.6)